### PR TITLE
Use deploy-pages action to deploy docs directly without `gh-pages` branch

### DIFF
--- a/.github/workflows/sphinx-docs.yaml
+++ b/.github/workflows/sphinx-docs.yaml
@@ -6,28 +6,50 @@ on:
       - main
 
 jobs:
-  publish_sphinx_docs:
+  build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Setup Python
+        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
       - name: Install dependencies
         run: |
-          pip install -e .
+          pip install .
           pip install -r docs/requirements.txt
-      - name: Sphinx build
+
+      - name: Build docs
         run: |
+          cd docs 
           sphinx-build docs docs/_build/html
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
-          publish_branch: gh-pages
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs/_build/html
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
-          force_orphan: true
+          path: ./docs/_build/html
+
+  deploy:
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
GitHub is moving towards getting people to use the `deploy-pages` action to deploy docs directly without the `gh-pages` branch.

You will need to change your Pages settings from "a branch" to "GitHub Actions" or the deploy job will fail.

ref: https://github.blog/changelog/2024-07-08-pages-legacy-worker-sunset/