### PR TITLE
Remove setuptools find configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,14 +29,6 @@ dynamic = ["version"]
 [tool.setuptools.dynamic]
 version = {attr = "batgrl.__version__"}
 
-[tool.setuptools.packages.find]
-where = ["src"]
-exclude = [
-    "docs**",
-    "examples**",
-    "preview_images**",
-]
-
 [tool.ruff.lint]
 select = [
     "D",  # pydocstyle


### PR DESCRIPTION
`src/` is already the default.
The `exclude`s are a legacy from before the package switched to the src layout.