### PR TITLE
vt100_terminal.py: fix (?) mouse support on Linux

### DIFF
--- a/src/batgrl/terminal/vt100_terminal.py
+++ b/src/batgrl/terminal/vt100_terminal.py
@@ -401,7 +401,6 @@ class Vt100Terminal(ABC):
         self._out_buffer.append(
             "\x1b[?1000h"  # SET_VT200_MOUSE
             "\x1b[?1003h"  # SET_ANY_EVENT_MOUSE
-            "\x1b[?1015h"  # SET_URXVT_EXT_MODE_MOUSE
             "\x1b[?1006h"  # SET_SGR_EXT_MODE_MOUSE
         )
 
@@ -410,8 +409,7 @@ class Vt100Terminal(ABC):
         self._out_buffer.append(
             "\x1b[?1000l"  # SET_VT200_MOUSE
             "\x1b[?1003l"  # SET_ANY_EVENT_MOUSE
-            "\x1b[?1015l"  # SET_SGR_EXT_MODE_MOUSE
-            "\x1b[?1006l"  # SET_URXVT_EXT_MODE_MOUSE
+            "\x1b[?1006l"  # SET_SGR_EXT_MODE_MOUSE
         )
 
     def reset_attributes(self) -> None:

--- a/src/batgrl/terminal/vt100_terminal.py
+++ b/src/batgrl/terminal/vt100_terminal.py
@@ -401,8 +401,8 @@ class Vt100Terminal(ABC):
         self._out_buffer.append(
             "\x1b[?1000h"  # SET_VT200_MOUSE
             "\x1b[?1003h"  # SET_ANY_EVENT_MOUSE
-            "\x1b[?1006h"  # SET_SGR_EXT_MODE_MOUSE
             "\x1b[?1015h"  # SET_URXVT_EXT_MODE_MOUSE
+            "\x1b[?1006h"  # SET_SGR_EXT_MODE_MOUSE
         )
 
     def disable_mouse_support(self) -> None:


### PR DESCRIPTION
This patch restores batgrl's ability to work with:

- xterm
- konsole
- kitty
- ghostty

(tested on Fedora 41 KDE remix)

I wish I could explain why changing the order of these commands is necessary! This patch was authored through trial and error. However, it just so happens to bring back enable_mouse_support to the contents it had in e726ea8de003fb3f0fd9c59dc2bc2c8929b051ea. It appears that this might be a bug that was introduced in the refactoring of commit 2f594edae4388f1502b78789aa31957abd264dfe ("v0.35.0") and made enable_mouse_support and disable_mouse_support stop looking alike.