### PR TITLE
Reformat C code

### DIFF
--- a/src/batgrl/terminal/_fbuf.h
+++ b/src/batgrl/terminal/_fbuf.h
@@ -11,7 +11,7 @@
 #ifdef _WIN32
     #include <Windows.h>
     #include <io.h>
-    typedef SSIZE_T ssize_t;
+typedef SSIZE_T ssize_t;
 #else
     #include <unistd.h>
     #include <poll.h>
@@ -19,77 +19,92 @@
 
 
 typedef struct fbuf {
-  uint64_t size;
-  uint64_t len;
-  char *buf;
+    uint64_t size;
+    uint64_t len;
+    char *buf;
 } fbuf;
 
 
-static inline ssize_t fbuf_init(fbuf *f){
+static inline ssize_t
+fbuf_init(fbuf *f) {
     f->size = 0x200000ul;
     f->len = 0;
-    f->buf = (char*)malloc(f->size);
-    if(f->buf == NULL) return -1;
+    f->buf = (char *)malloc(f->size);
+    if (f->buf == NULL) {
+        return -1;
+    }
     return 0;
 }
 
-
-static inline ssize_t fbuf_small_init(fbuf *f){
+static inline ssize_t
+fbuf_small_init(fbuf *f) {
     f->size = 0x200ul;
     f->len = 0;
-    f->buf = (char*)malloc(f->size);
-    if(f->buf == NULL) return -1;
+    f->buf = (char *)malloc(f->size);
+    if (f->buf == NULL) {
+        return -1;
+    }
     return 0;
 }
 
-
-static inline void fbuf_free(fbuf *f){
+static inline void
+fbuf_free(fbuf *f) {
     f->size = 0;
     f->len = 0;
-    if(f->buf != NULL){
+    if (f->buf != NULL) {
         free(f->buf);
         f->buf = NULL;
     }
 }
 
-
-static inline ssize_t fbuf_grow(fbuf *f, size_t n){
-    if(f->len + n <= f->size) return 0;
-    while(f->len + n > f->size){
+static inline ssize_t
+fbuf_grow(fbuf *f, size_t n) {
+    if (f->len + n <= f->size) {
+        return 0;
+    }
+    while (f->len + n > f->size) {
         f->size *= 2;
     }
     void *tmp = realloc(f->buf, f->size);
-    if(tmp == NULL) return -1;
-    f->buf = (char*)tmp;
+    if (tmp == NULL) {
+        return -1;
+    }
+    f->buf = (char *)tmp;
     return 0;
 }
 
-
-static inline ssize_t fbuf_put_char(fbuf *f, const char s){
-    if(fbuf_grow(f, 1)) return -1;
+static inline ssize_t
+fbuf_put_char(fbuf *f, const char s) {
+    if (fbuf_grow(f, 1)) {
+        return -1;
+    }
     f->buf[f->len++] = s;
     return 0;
 }
 
-
-static inline ssize_t fbuf_putn(fbuf *f, const char *s, size_t len){
-    if(fbuf_grow(f, len)) return -1;
+static inline ssize_t
+fbuf_putn(fbuf *f, const char *s, size_t len) {
+    if (fbuf_grow(f, len)) {
+        return -1;
+    }
     memcpy(f->buf + f->len, s, len);
     f->len += len;
     return 0;
 }
 
-
-static inline ssize_t fbuf_puts(fbuf *f, const char *s){
-  size_t slen = strlen(s);
-  return fbuf_putn(f, s, slen);
+static inline ssize_t
+fbuf_puts(fbuf *f, const char *s) {
+    size_t slen = strlen(s);
+    return fbuf_putn(f, s, slen);
 }
 
-
-static inline ssize_t fbuf_printf(fbuf *f, const char *fmt, ...){
+static inline ssize_t
+fbuf_printf(fbuf *f, const char *fmt, ...) {
     size_t unused = f->size - f->len;
-    if(unused < BUFSIZ){
-        if(fbuf_grow(f, BUFSIZ))return -1;
+    if (unused < BUFSIZ) {
+        if (fbuf_grow(f, BUFSIZ)) {
+            return -1;
+        }
     }
     va_list va;
     va_start(va, fmt);
@@ -99,70 +114,87 @@ static inline ssize_t fbuf_printf(fbuf *f, const char *fmt, ...){
     return 0;
 }
 
-
-static inline ssize_t fbuf_putucs4(fbuf *f, uint32_t wc){
+static inline ssize_t
+fbuf_putucs4(fbuf *f, uint32_t wc) {
     // Put PY_UCS4 as utf8.
     // https://github.com/JeffBezanson/cutef8/blob/master/utf8.c
-    if(fbuf_grow(f, 4)){
+    if (fbuf_grow(f, 4)) {
         return -1;
     }
-    if(wc < 0x80){
+    if (wc < 0x80) {
         f->buf[f->len++] = (char)wc;
         return 0;
     }
-    if(wc < 0x800){
-        f->buf[f->len++] = (wc>>6) | 0xc0;
+    if (wc < 0x800) {
+        f->buf[f->len++] = (wc >> 6) | 0xc0;
         f->buf[f->len++] = (wc & 0x3f) | 0x80;
         return 0;
     }
-    if(wc < 0x10000){
-        f->buf[f->len++] = (wc>>12) | 0xe0;
-        f->buf[f->len++] = ((wc>>6) & 0x3f) | 0x80;
+    if (wc < 0x10000) {
+        f->buf[f->len++] = (wc >> 12) | 0xe0;
+        f->buf[f->len++] = ((wc >> 6) & 0x3f) | 0x80;
         f->buf[f->len++] = (wc & 0x3f) | 0x80;
         return 0;
     }
-    if(wc < 0x110000) {
-        f->buf[f->len++] = (wc>>18) | 0xf0;
-        f->buf[f->len++] = ((wc>>12) & 0x3f) | 0x80;
-        f->buf[f->len++] = ((wc>>6) & 0x3f) | 0x80;
+    if (wc < 0x110000) {
+        f->buf[f->len++] = (wc >> 18) | 0xf0;
+        f->buf[f->len++] = ((wc >> 12) & 0x3f) | 0x80;
+        f->buf[f->len++] = ((wc >> 6) & 0x3f) | 0x80;
         f->buf[f->len++] = (wc & 0x3f) | 0x80;
         return 0;
     }
     return -1;
 }
 
-
-static inline unsigned int fbuf_equals(fbuf *f, const char *string, size_t len){
-    if(f->len != len) return 0;
-    for(size_t i = 0; i < len; i++){
-        if(f->buf[i] != string[i]) return 0;
+static inline unsigned int
+fbuf_equals(fbuf *f, const char *string, size_t len) {
+    if (f->len != len) {
+        return 0;
+    }
+    for (size_t i = 0; i < len; i++) {
+        if (f->buf[i] != string[i]) {
+            return 0;
+        }
     }
     return 1;
 }
 
-
-static inline unsigned int fbuf_endswith(fbuf *f, const char *suffix, size_t len){
-    if(len > f->len) return 0;
+static inline unsigned int
+fbuf_endswith(fbuf *f, const char *suffix, size_t len) {
+    if (len > f->len) {
+        return 0;
+    }
     size_t offset = f->len - len;
-    for(size_t i = 0; i < len; i++ ){
-        if(f->buf[offset + i] != suffix[i]) return 0;
+    for (size_t i = 0; i < len; i++ ) {
+        if (f->buf[offset + i] != suffix[i]) {
+            return 0;
+        }
     }
     return 1;
 }
-
 
 #ifdef _WIN32
-static inline ssize_t fbuf_flush_fd(fbuf *f, int fd){
+static inline ssize_t
+fbuf_flush_fd(fbuf *f, int fd) {
     HANDLE handle = (HANDLE)_get_osfhandle(fd);
     DWORD wrote = 0, write_len;
     size_t written = 0;
-    while(written<f->len){
-        if(f->len - written > MAXDWORD){
+    while (written < f->len) {
+        if (f->len - written > MAXDWORD) {
             write_len = MAXDWORD;
-        }else{
+        }
+        else {
             write_len = (DWORD)(f->len - written);
         }
-        if (!WriteConsoleA(handle, f->buf + written, write_len, &wrote, NULL)){
+        if (
+            !WriteConsoleA(
+                handle,
+                f->buf + written,
+                write_len,
+                &wrote,
+                NULL
+            )
+        ) {
             return -1;
         }
         written += wrote;
@@ -170,7 +202,6 @@ static inline ssize_t fbuf_flush_fd(fbuf *f, int fd){
     f->len = 0;
     return 0;
 }
-
 
 typedef unsigned long codepoint;
 codepoint GENERIC_SURROGATE_MASK = 0xf800;
@@ -184,53 +215,73 @@ unsigned char SURROGATE_CODEPOINT_BITS = 10;
 codepoint _HIGH_SURROGATE = 0;
 
 
-static inline ssize_t decode_utf16(fbuf *f, unsigned short utf16){
-    if((utf16 & GENERIC_SURROGATE_MASK) != GENERIC_SURROGATE_VALUE){
+static inline ssize_t
+decode_utf16(fbuf *f, unsigned short utf16) {
+    if ((utf16 & GENERIC_SURROGATE_MASK) != GENERIC_SURROGATE_VALUE) {
         _HIGH_SURROGATE = 0;
-        if(fbuf_putucs4(f, (codepoint)utf16)) return -1;
-    }else if((utf16 & SURROGATE_MASK) == HIGH_SURROGATE_VALUE){
+        if (fbuf_putucs4(f, (codepoint)utf16)) {
+            return -1;
+        }
+    }
+    else if ((utf16 & SURROGATE_MASK) == HIGH_SURROGATE_VALUE) {
         _HIGH_SURROGATE = (codepoint)utf16;
-    }else if(
-        ((utf16 & SURROGATE_MASK) == LOW_SURROGATE_VALUE) && _HIGH_SURROGATE
-    ){
+    }
+    else if (
+             ((utf16 & SURROGATE_MASK) == LOW_SURROGATE_VALUE) &&
+             _HIGH_SURROGATE
+    ) {
         codepoint result = _HIGH_SURROGATE & SURROGATE_CODEPOINT_MASK;
         result <<= SURROGATE_CODEPOINT_BITS;
         result |= utf16 & SURROGATE_CODEPOINT_MASK;
         result += SURROGATE_CODEPOINT_OFFSET;
         _HIGH_SURROGATE = 0;
-        if(fbuf_putucs4(f, result)) return -1;
+        if (fbuf_putucs4(f, result)) {
+            return -1;
+        }
     }
     return 0;
 }
 
-
-static inline ssize_t fbuf_read_fd(fbuf *f, int fd, int *size_event){
+static inline ssize_t
+fbuf_read_fd(fbuf *f, int fd, int *size_event) {
     HANDLE handle = (HANDLE)_get_osfhandle(fd);
     DWORD nevents, events_to_read, events_read;
-    if(!GetNumberOfConsoleInputEvents(handle, &nevents)) return -1;
-    INPUT_RECORD *records = (INPUT_RECORD*)malloc(sizeof(INPUT_RECORD) * nevents);
-    if(!records) return -1;
+    if (!GetNumberOfConsoleInputEvents(handle, &nevents)) {
+        return -1;
+    }
+    INPUT_RECORD *records = (INPUT_RECORD *)malloc(
+        sizeof(INPUT_RECORD) *
+        nevents
+    );
+    if (!records) {
+        return -1;
+    }
     events_to_read = nevents;
-    while(events_to_read){
-        if(!ReadConsoleInputW(handle, records, nevents, &events_read)){
+    while (events_to_read) {
+        if (!ReadConsoleInputW(handle, records, nevents, &events_read)) {
             free(records);
             return -1;
         }
         events_to_read -= events_read;
     }
-    for(size_t i = 0; i < nevents; i++){
+    for (size_t i = 0; i < nevents; i++) {
         INPUT_RECORD *record = &records[i];
-        if(record->EventType == KEY_EVENT){
-            if(!record->Event.KeyEvent.bKeyDown) continue;
-            if(
+        if (record->EventType == KEY_EVENT) {
+            if (!record->Event.KeyEvent.bKeyDown) {
+                continue;
+            }
+            if (
                 record->Event.KeyEvent.dwControlKeyState
                 && !record->Event.KeyEvent.wVirtualKeyCode
-            ) continue;
-            if(decode_utf16(f, record->Event.KeyEvent.uChar.UnicodeChar)){
+            ) {
+                continue;
+            }
+            if (decode_utf16(f, record->Event.KeyEvent.uChar.UnicodeChar)) {
                 free(records);
                 return 1;
             }
-        }else if(record->EventType == WINDOW_BUFFER_SIZE_EVENT){
+        }
+        else if (record->EventType == WINDOW_BUFFER_SIZE_EVENT) {
             size_event[0] = (int)record->Event.WindowBufferSizeEvent.dwSize.Y;
             size_event[1] = (int)record->Event.WindowBufferSizeEvent.dwSize.X;
         }
@@ -238,35 +289,48 @@ static inline ssize_t fbuf_read_fd(fbuf *f, int fd, int *size_event){
     free(records);
     return 0;
 }
+
 #else
-static inline ssize_t fbuf_flush_fd(fbuf *f, int fd){
+static inline ssize_t
+fbuf_flush_fd(fbuf *f, int fd) {
     size_t written = 0;
     ssize_t wrote = 0;
-    while(written < f->len){
+    while (written < f->len) {
         wrote = write(fd, f->buf + written, f->len - written);
-        if (wrote < 0) return -1;
+        if (wrote < 0) {
+            return -1;
+        }
         written += wrote;
     }
     f->len = 0;
     return 0;
 }
 
-
-static inline ssize_t fbuf_read_fd(fbuf *f, int fd, int *size_event){
+static inline ssize_t
+fbuf_read_fd(fbuf *f, int fd, int *size_event) {
     struct pollfd pfd = {
         .fd = fd,
         .events = POLLIN,
     };
     size_t MAX_READ = 1024;
 
-    while(1){
+    while (1) {
         int retval = poll(&pfd, 1, 0);
-        if(retval == 0) return 0;
-        if(retval < 0) return -1;
-        if(fbuf_grow(f, MAX_READ)) return 1;
+        if (retval == 0) {
+            return 0;
+        }
+        if (retval < 0) {
+            return -1;
+        }
+        if (fbuf_grow(f, MAX_READ)) {
+            return 1;
+        }
         ssize_t amt = read(fd, f->buf + f->len, MAX_READ);
-        if(amt < 0) return -1;
+        if (amt < 0) {
+            return -1;
+        }
         f->len += amt;
     }
 }
+
 #endif

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1,0 +1,109 @@
+# PEP 7 Compliant Uncrustify Configuration
+# Use 'uncrustify -c uncrustify.cfg --replace --no-backup src/batgrl/terminal/_fbuf.h'
+
+# General code size
+code_width = 79
+input_tab_size = 8
+output_tab_size = 4
+indent_columns = 4
+indent_with_tabs = 0
+
+# Ugly Newlines
+nl_struct_brace = remove
+nl_else_brace = remove
+nl_brace_else = force
+nl_if_brace = remove
+nl_else_if = remove
+nl_for_brace = remove
+nl_while_brace = remove
+nl_before_opening_brace_func_class_def = force
+nl_after_case = true
+nl_case_colon_brace = remove
+
+# Misc Newlines
+nl_multi_line_sparen_open = force
+nl_multi_line_sparen_close = force
+nl_after_func_body = 2
+nl_after_struct = 1
+nl_assign_leave_one_liners = true
+nl_assign_brace = remove
+
+# Operators
+sp_arith = force
+sp_assign = force
+sp_compare = force
+sp_before_byref = force
+sp_after_byref = remove
+indent_ternary_operator = 2
+
+# Parens
+sp_after_paren = force
+sp_before_sparen = force
+sp_inside_sparen = remove
+indent_paren_close = 2
+sp_paren_brace = force
+
+# Semicolons
+sp_before_semi = remove
+sp_before_semi_for = remove
+sp_before_semi_for_empty = remove
+sp_between_semi_for_empty = remove
+
+# Square Brackets
+sp_before_square = remove
+sp_before_vardef_square = remove
+sp_inside_square = remove
+
+# Commas
+sp_before_comma = remove
+sp_after_comma = force
+sp_paren_comma = remove
+
+# Braces
+sp_inside_braces_empty = remove
+sp_sparen_brace = force
+nl_assign_brace = remove
+sp_brace_else = force
+sp_else_brace = force
+mod_full_brace_if = true
+
+# Pointers
+sp_before_ptr_star = force
+sp_before_unnamed_ptr_star = force
+sp_after_ptr_star = remove
+sp_ptr_star_paren = remove
+sp_between_ptr_star = remove
+
+# Function Definitions
+sp_type_func = force
+nl_func_def_paren = remove
+nl_func_type_name = force
+nl_func_leave_one_liners = true
+nl_func_def_args_multi_line = true
+nl_func_def_start_multi_line = true
+nl_func_def_end_multi_line = true
+donot_indent_func_def_close_paren = true
+sp_fparen_brace = force
+
+# Function Declarations
+nl_func_decl_start_multi_line = true
+nl_func_decl_args_multi_line = true
+nl_func_decl_end_multi_line = true
+
+# Macros
+sp_macro = force
+sp_macro_func = remove
+indent_macro_brace = true
+nl_multi_line_define = true
+nl_define_macro = true
+align_nl_cont = 1
+
+# Function Calls
+nl_func_call_empty = remove
+nl_func_call_paren = remove
+nl_func_call_start_multi_line = true
+nl_func_call_end_multi_line = true
+nl_func_call_args_multi_line = true
+indent_func_call_param = true
+indent_paren_after_func_call = false
+indent_align_paren = false


### PR DESCRIPTION
I'm (mostly) following [PEP 7](https://peps.python.org/pep-0007/) here. You can rerun the formatter using `uncrustify -c uncrustify.cfg --replace --no-backup src/batgrl/terminal/_fbuf.h`.